### PR TITLE
Add Seafile Storage whitelist in Seedvault.

### DIFF
--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -14,6 +14,7 @@
     <string-array name="storage_authority_whitelist" tools:ignore="InconsistentArrays">
         <item>com.android.externalstorage.documents</item>
         <item>org.nextcloud.documents</item>
+        <item>com.seafile.seadroid2</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
Hi,

Here is a tiny PR to add the capability to backup on self hosted storage app seafile (seadroid).

I opened an issue long time ago here https://github.com/stevesoltys/seedvault/issues/84#issuecomment-676609325 .
And I understand that finally I need to make a PR here. 

I add com.seafile.seadroid2 in whitelisted app, next to nextcloud.

According to those links, this should work:

https://github.com/haiwen/seadroid/blob/a9d7c2a2b11aa39150acfcdd421a9e612cb936f7/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java#L116

where in nextcloud in the same function:

https://github.com/nextcloud/android/blob/c57448e32c4d1ff41c00bc99a63665f3ca546e7a/src/main/java/com/owncloud/android/providers/DocumentsStorageProvider.java#L138

they use

https://github.com/nextcloud/android/blob/c57448e32c4d1ff41c00bc99a63665f3ca546e7a/src/main/res/values/setup.xml#L13

Thanks !